### PR TITLE
Fixed the cycle animation for the 16:9 Countdown Display

### DIFF
--- a/Assets/Assets/Displays/CountdownDisplay/Animations/OneScreen/CountdownDisplayController.controller
+++ b/Assets/Assets/Displays/CountdownDisplay/Animations/OneScreen/CountdownDisplayController.controller
@@ -116,7 +116,7 @@ AnimatorState:
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
-  m_WriteDefaultValues: 0
+  m_WriteDefaultValues: 1
   m_Mirror: 0
   m_SpeedParameterActive: 0
   m_MirrorParameterActive: 0
@@ -163,7 +163,7 @@ AnimatorState:
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
-  m_WriteDefaultValues: 0
+  m_WriteDefaultValues: 1
   m_Mirror: 0
   m_SpeedParameterActive: 0
   m_MirrorParameterActive: 0

--- a/Assets/Assets/Scenes/MainScene.unity
+++ b/Assets/Assets/Scenes/MainScene.unity
@@ -16965,7 +16965,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b8e1ebf27420da4c99bd5680d4e2ce6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  timeDriven: 0
+  timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
   animators:


### PR DESCRIPTION
Set the WriteToDefaults param to false in the idle
animation and set the TimeDriven param to true
in the Countdown Display Manager