### PR TITLE
Video Display transition fixed when no video is found

### DIFF
--- a/Assets/Assets/Scenes/MainScene.unity
+++ b/Assets/Assets/Scenes/MainScene.unity
@@ -2257,6 +2257,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 20
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 1607986881}
   - {fileID: 83343769}
@@ -6536,6 +6537,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 16
   readyToCycle: 0
+  forceCycle: 0
   animators: []
   videoContainer: {fileID: 882805181}
   transparent: {fileID: 2800000, guid: 9eb7f1625b10b0941a6de2fe72b076d7, type: 3}
@@ -8915,6 +8917,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 826708585}
   modifier: 2.5
@@ -17805,6 +17808,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 962993824}
   conferenceTitleText: {fileID: 1801068659}
@@ -20231,6 +20235,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 16
   readyToCycle: 0
+  forceCycle: 0
   animators: []
   videoContainer: {fileID: 1376059217}
   transparent: {fileID: 2800000, guid: 9eb7f1625b10b0941a6de2fe72b076d7, type: 3}
@@ -22170,6 +22175,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 2114339953}
   boxes:
@@ -23153,6 +23159,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 20
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 623339408}
   photos: []
@@ -24116,6 +24123,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 31
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 155676700}
   switchTime: 8
@@ -26661,6 +26669,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 20
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 1127705916}
   - {fileID: 750352925}
@@ -28523,6 +28532,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 1715046526}
   - {fileID: 1393051338}
@@ -30446,6 +30456,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 31
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 2013474155}
   - {fileID: 961229215}
@@ -39645,6 +39656,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 1071730191}
   influencersContainers:
@@ -41810,6 +41822,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 1656652953}
   - {fileID: 2140779652}
@@ -46526,6 +46539,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 20
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 36452576}
   leftScreenTitle: Post your Dreamforce photos!
@@ -50345,6 +50359,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 1952923797}
   - {fileID: 1731315926}
@@ -51524,6 +51539,7 @@ MonoBehaviour:
   timeDriven: 1
   cycleTime: 15
   readyToCycle: 0
+  forceCycle: 0
   animators:
   - {fileID: 1517994963}
   - {fileID: 501338670}

--- a/Assets/Assets/Scripts/Display/DisplayController.cs
+++ b/Assets/Assets/Scripts/Display/DisplayController.cs
@@ -75,11 +75,11 @@ public class DisplayController: MonoBehaviour {
 
 
 		_readyToCycle = (_currentDisplayManager.timeDriven && Time.time - _lastCycleTime > _currentDisplayManager.cycleTime) ||
-			(!_currentDisplayManager.timeDriven && _currentDisplayManager.readyToCycle);
+			(!_currentDisplayManager.timeDriven && _currentDisplayManager.readyToCycle) || _currentDisplayManager.forceCycle;
 
 		if (_readyToCycle)
 		{
-			if(!_cyclingDisplay)
+			if(!_cyclingDisplay && !_currentDisplayManager.forceCycle)
 			{
 				//Start the out animation for every avaialable display animator
 				foreach(Animator displayAnimator in _currentDisplayManager.animators)
@@ -99,7 +99,7 @@ public class DisplayController: MonoBehaviour {
 
 				stillCycling = !_currentDisplayManager.DisplayOutFinished;
 
-				if(!stillCycling)
+				if(!stillCycling && !_currentDisplayManager.forceCycle)
 				{
 					//We check in every display animator if the out animation finished
 					foreach(Animator displayAnimator in _currentDisplayManager.animators)

--- a/Assets/Assets/Scripts/Display/IDisplayManager.cs
+++ b/Assets/Assets/Scripts/Display/IDisplayManager.cs
@@ -6,6 +6,7 @@ public abstract class IDisplayManager : MonoBehaviour {
 	public bool timeDriven = true;
 	public float cycleTime = 10f;
 	public bool readyToCycle = false;
+	public bool forceCycle = false;
 
 	protected int _displayId;
 	protected bool _displayOutFinished = false;

--- a/Assets/Assets/Scripts/Display/VideoDisplayManager.cs
+++ b/Assets/Assets/Scripts/Display/VideoDisplayManager.cs
@@ -20,6 +20,7 @@ public class VideoDisplayManager : IDisplayManager {
 	
 	public override void InitializeDisplay (int displayId)
 	{
+		forceCycle = false;
 		cycleTime = 30f;
 		_initialized = false;
 		_displayId = displayId;
@@ -47,7 +48,7 @@ public class VideoDisplayManager : IDisplayManager {
 		movie.Stop ();
 		
 		float movieDuration = Preloader.instance.GetDisplayDuration (Preloader.instance.GetRunningDisplay());
-		
+
 		cycleTime = movieDuration + (Time.time - _loadStartTime);
 		
 		movie.loop = false;
@@ -136,6 +137,7 @@ public class VideoDisplayManager : IDisplayManager {
 			else
 			{
 				cycleTime = 0;
+				forceCycle = true;
 			}
 			
 			return false;


### PR DESCRIPTION
If for some reason the video cannot be loaded the display must
go for the next one. That was not happening due to a bug in the flow.
Now, a new flag named forceCycle will force the transition to the
next without waiting for any animations to finish.